### PR TITLE
Docker setup to run tests in a portable environment

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,3 @@
 IMAGE_TAG=latest
 PIPENV_DEV_ARG=--dev
+PYTHON_BASE_IMAGE_TAG=3.6.6-alpine3.8

--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+IMAGE_TAG=latest
+PIPENV_DEV_ARG=--dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+ARG image_tag=latest
+FROM libero/content-store_venv:${image_tag} as venv
+FROM python:3.6.6-alpine3.8
+
+WORKDIR /app
+COPY api/ api/
+COPY --from=venv /app/.venv/ .venv/
+
+CMD [".venv/bin/python"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 ARG image_tag=latest
+ARG python_base_image_tag
 FROM libero/content-store_venv:${image_tag} as venv
-FROM python:3.6.6-alpine3.8
+FROM python:${python_base_image_tag}
 
 WORKDIR /app
 COPY api/ api/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,11 @@ ARG python_base_image_tag
 FROM libero/content-store_venv:${image_tag} as venv
 FROM python:${python_base_image_tag}
 
-WORKDIR /app
-COPY api/ api/
 COPY --from=venv /.venv/ /.venv/
 ENV PYTHONUSERBASE=/.venv PATH=/.venv/bin:$PATH
+
+WORKDIR /app
+COPY api/ api/
+# if there is work to be done here, move the venv copying after it
 
 CMD ["python"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM python:3.6.6-alpine3.8
 
 WORKDIR /app
 COPY api/ api/
-COPY --from=venv /app/.venv/ .venv/
+COPY --from=venv /.venv/ /.venv/
+ENV PYTHONUSERBASE=/.venv PATH=/.venv/bin:$PATH
 
-CMD [".venv/bin/python"]
+CMD ["python"]

--- a/Dockerfile.venv
+++ b/Dockerfile.venv
@@ -1,4 +1,5 @@
-FROM python:3.6.6-alpine3.8
+ARG python_base_image_tag
+FROM python:${python_base_image_tag}
 RUN pip install --no-cache-dir --only-binary --upgrade pipenv
 
 COPY Pipfile Pipfile.lock ./

--- a/Dockerfile.venv
+++ b/Dockerfile.venv
@@ -1,7 +1,6 @@
 FROM python:3.6.6-alpine3.8
 RUN pip install --no-cache-dir --only-binary --upgrade pipenv
 
-WORKDIR /app
 COPY Pipfile Pipfile.lock ./
 
 ARG pipenv_dev_arg

--- a/Dockerfile.venv
+++ b/Dockerfile.venv
@@ -1,9 +1,9 @@
 FROM python:3.6.6-alpine3.8
 RUN pip install --no-cache-dir --only-binary --upgrade pipenv
 
-ARG pipenv_dev_arg
-
 WORKDIR /app
 COPY Pipfile Pipfile.lock ./
+
+ARG pipenv_dev_arg
 ENV PIPENV_VENV_IN_PROJECT=1 
 RUN pipenv install ${pipenv_dev_arg} --deploy

--- a/Dockerfile.venv
+++ b/Dockerfile.venv
@@ -6,4 +6,4 @@ COPY Pipfile Pipfile.lock ./
 
 ARG pipenv_dev_arg
 ENV PIPENV_VENV_IN_PROJECT=1 
-RUN pipenv install ${pipenv_dev_arg} --deploy
+RUN pipenv install ${pipenv_dev_arg} --deploy --ignore-pipfile

--- a/Dockerfile.venv
+++ b/Dockerfile.venv
@@ -1,0 +1,9 @@
+FROM python:3.6.6-alpine3.8
+RUN pip install --no-cache-dir --only-binary --upgrade pipenv
+
+ARG pipenv_dev_arg
+
+WORKDIR /app
+COPY Pipfile Pipfile.lock ./
+ENV PIPENV_VENV_IN_PROJECT=1 
+RUN pipenv install ${pipenv_dev_arg} --deploy

--- a/README.md
+++ b/README.md
@@ -1,7 +1,21 @@
 Libero content store
 ====================
 
+## Development
+
 Running the app:
 ```
 FLASK_APP=api/api.py pipenv run flask run
+```
+
+## Docker setup
+
+Build images:
+```
+docker-compose build
+```
+
+Run tests:
+```
+docker-compose run cli .venv/bin/python -m pytest
 ```

--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ Running the application:
 docker-compose up -d
 ```
 
+Running the application locally (to be removed when Docker becomes the primary development mode):
+```
+FLASK_APP=api/api.py pipenv run flask run
+```
+
 Checking the application is responding:
 ```
 curl -v localhost:5000/ping

--- a/README.md
+++ b/README.md
@@ -20,5 +20,5 @@ curl -v localhost:5000/ping
 
 Running tests:
 ```
-docker-compose run cli .venv/bin/python -m pytest
+docker-compose run cli python -m pytest
 ```

--- a/README.md
+++ b/README.md
@@ -25,5 +25,5 @@ curl -v localhost:5000/ping
 
 Running tests:
 ```
-docker-compose run cli python -m pytest
+docker-compose run web python -m pytest
 ```

--- a/README.md
+++ b/README.md
@@ -3,29 +3,22 @@ Libero content store
 
 ## Development
 
-Running the app:
-```
-FLASK_APP=api/api.py pipenv run flask run
-```
-
-## Docker setup
-
-Build images:
+Building images:
 ```
 docker-compose build
 ```
 
-Run the application:
+Running the application:
 ```
 docker-compose up -d
 ```
 
-Check the application is responding:
+Checking the application is responding:
 ```
 curl -v localhost:5000/ping
 ```
 
-Run tests:
+Running tests:
 ```
 docker-compose run cli .venv/bin/python -m pytest
 ```

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ Run the application:
 docker-compose up -d
 ```
 
+Check the application is responding:
+```
+curl -v localhost:5000/ping
+```
+
 Run tests:
 ```
 docker-compose run cli .venv/bin/python -m pytest

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ Build images:
 docker-compose build
 ```
 
+Run the application:
+```
+docker-compose up -d
+```
+
 Run tests:
 ```
 docker-compose run cli .venv/bin/python -m pytest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,8 @@ services:
         image: libero/digests:${IMAGE_TAG}
         environment:
             - FLASK_APP=api/api.py
-        command: .venv/bin/flask run
+        # TODO: doesn't handle SIGTERM?
+        command: .venv/bin/flask run --host=0.0.0.0
         ports:
             - 5000:5000
         depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3'
+
+services:
+    venv:
+        build:
+            context: .
+            dockerfile: Dockerfile.venv
+            args:
+                pipenv_dev_arg: ${PIPENV_DEV_ARG}
+        image: libero/digests_venv:${IMAGE_TAG}
+    cli:
+        build:
+            context: .
+            dockerfile: Dockerfile
+            args:
+                image_tag: ${IMAGE_TAG}
+        image: libero/digests:${IMAGE_TAG}
+        depends_on:
+            - venv
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,14 +7,14 @@ services:
             dockerfile: Dockerfile.venv
             args:
                 pipenv_dev_arg: ${PIPENV_DEV_ARG}
-        image: libero/digests_venv:${IMAGE_TAG}
+        image: libero/content-store_venv:${IMAGE_TAG}
     cli:
         build:
             context: .
             dockerfile: Dockerfile
             args:
                 image_tag: ${IMAGE_TAG}
-        image: libero/digests:${IMAGE_TAG}
+        image: libero/content-store:${IMAGE_TAG}
         environment:
             - FLASK_APP=api/api.py
         command: .venv/bin/flask run --host=0.0.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
             dockerfile: Dockerfile.venv
             args:
                 pipenv_dev_arg: ${PIPENV_DEV_ARG}
+                python_base_image_tag: ${PYTHON_BASE_IMAGE_TAG}
         image: libero/content-store_venv:${IMAGE_TAG}
     web:
         build:
@@ -14,6 +15,7 @@ services:
             dockerfile: Dockerfile
             args:
                 image_tag: ${IMAGE_TAG}
+                python_base_image_tag: ${PYTHON_BASE_IMAGE_TAG}
         image: libero/content-store:${IMAGE_TAG}
         environment:
             - FLASK_APP=api/api.py

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
             args:
                 pipenv_dev_arg: ${PIPENV_DEV_ARG}
         image: libero/content-store_venv:${IMAGE_TAG}
-    cli:
+    web:
         build:
             context: .
             dockerfile: Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,11 @@ services:
             args:
                 image_tag: ${IMAGE_TAG}
         image: libero/digests:${IMAGE_TAG}
+        environment:
+            - FLASK_APP=api/api.py
+        command: .venv/bin/flask run
+        ports:
+            - 5000:5000
         depends_on:
             - venv
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,8 @@ services:
         image: libero/digests:${IMAGE_TAG}
         environment:
             - FLASK_APP=api/api.py
-        # TODO: doesn't handle SIGTERM?
         command: .venv/bin/flask run --host=0.0.0.0
+        stop_signal: SIGINT
         ports:
             - 5000:5000
         depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,4 +23,3 @@ services:
             - 5000:5000
         depends_on:
             - venv
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
         image: libero/content-store:${IMAGE_TAG}
         environment:
             - FLASK_APP=api/api.py
-        command: .venv/bin/flask run --host=0.0.0.0
+        command: flask run --host=0.0.0.0
         stop_signal: SIGINT
         ports:
             - 5000:5000


### PR DESCRIPTION
- Add `venv` image
- Add main `web` image
- Add docker-compose setup for building them
- Document how to run the application and tests

Out of scope: WSGI server, any volume mounting from the host.