### PR TITLE
Avoid clash in image names

### DIFF
--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -4,6 +4,7 @@ services:
     app:
         build:
             target: dev
+        image: libero/content-store_dev:${IMAGE_TAG:-master}
         volumes:
             - ./:/app
             - /app/var

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -4,3 +4,4 @@ services:
     app:
         build:
             target: test
+        image: libero/content-store_test:${IMAGE_TAG:-master}


### PR DESCRIPTION
We are currently pushing the `test` image because
```
docker-compose -f docker-compose.yaml -f docker-compose.test.yaml build
```
overwrites the local `prod` image previously generated with the same name.