### PR TITLE
Trigger environments pipeline after build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,12 @@ script:
 after_success:
     - .scripts/travis/push-image.sh content-store
 
+deploy:
+    provider: script
+    script: .scripts/travis/downstream.sh environments "Update content-store to $TRAVIS_COMMIT"
+    on:
+        branch: master
+
 if: |
     branch = master OR \
     branch =~ /^(?:[0-9]|[1-9][0-9]*)\.(?:[0-9]|[1-9][0-9]*)$/ OR \


### PR DESCRIPTION
For https://github.com/libero/libero/issues/117

Matches https://github.com/libero/pattern-library/blob/master/.travis.yml#L32-L35

`environments` is not ready yet to deploy this application, but the PR is not harmful as it will just generically trigger its pipeline.