### PR TITLE
Update ContentServiceTest.php

### DIFF
--- a/tests/ContentServiceTest.php
+++ b/tests/ContentServiceTest.php
@@ -107,7 +107,7 @@ final class ContentServiceTest extends KernelTestCase
         <service>articles</service>
     </meta>
     <article xmlns="http://jats.nlm.nih.gov" xmlns:xlink="http://www.w3.org/1999/xlink"
-        xml:base="http://origin-assets/new-article/">
+        xml:base="http://origin-assets/new-article">
         <front>
             <article-meta>
                 <title-group>

--- a/tests/ContentServiceTest.php
+++ b/tests/ContentServiceTest.php
@@ -142,7 +142,7 @@ XML
         <service>articles</service>
     </meta>
     <article xmlns="http://jats.nlm.nih.gov" xmlns:xlink="http://www.w3.org/1999/xlink"
-        xml:base="http://origin-assets/new-article/">
+        xml:base="http://origin-assets/new-article">
         <front>
             <article-meta>
                 <title-group>


### PR DESCRIPTION
test `xml:base` missing trailing slash.